### PR TITLE
Route Archidekt API traffic through server-side proxy to avoid CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npm run preview
 ## Notes
 
 - Archidekt requests are routed through a Vite server-side proxy at `/api/archidekt` to avoid browser CORS issues.
+- Scryfall requests are routed through `/api/scryfall` and de-duplicated in-flight to reduce 429/rate-limit failures during deck audits.
 - It uses:
   - Scryfall API for card/printing data
   - Archidekt API for deck/folder/user data

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm run preview
 
 ## Notes
 
-- This app is browser-only (no backend server).
+- Archidekt requests are routed through a Vite server-side proxy at `/api/archidekt` to avoid browser CORS issues.
 - It uses:
   - Scryfall API for card/printing data
   - Archidekt API for deck/folder/user data

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -266,8 +266,21 @@ function EntryPage({ onSubmit, history, mode, onModeChange }) {
   );
 }
 
+function formatFailureReason(reason) {
+  if (!reason) return '';
+
+  const map = {
+    rate_limited: 'Rate limited by Scryfall (retrying may help)',
+    network: 'Network/proxy request failed',
+    not_found: 'Card not found in Scryfall',
+    api_changed: 'Unexpected API response',
+  };
+
+  return map[reason] || reason;
+}
+
 function ResultsView({ audit, onBack }) {
-  const { phase, title, rows, totals, processed, total, cancel, reset, error } = audit;
+  const { phase, title, subtitle, rows, totals, processed, total, cancel, reset, error } = audit;
 
   const progress = total === 0 ? 0 : Math.round((processed / total) * 100);
   const done = phase === 'done';
@@ -296,7 +309,8 @@ function ResultsView({ audit, onBack }) {
         </button>
 
         <div style={{ flex: 1 }}>
-          <div style={{ fontSize: 18, fontWeight: 600, color: t.text, marginBottom: 6 }}>{title || 'Running audit…'}</div>
+          <div style={{ fontSize: 18, fontWeight: 600, color: t.text, marginBottom: 2 }}>{title || 'Running audit…'}</div>
+          {subtitle && <div style={{ fontSize: 12, color: t.textMuted, marginBottom: 6 }}>{subtitle}</div>}
           <ProgressBar value={progress} done={done} />
           <div style={{ display: 'flex', gap: 12, marginTop: 6, flexWrap: 'wrap' }}>
             <span style={{ fontSize: 12, color: t.textMuted }}>{processed}/{total} checked</span>
@@ -342,7 +356,14 @@ function ResultsView({ audit, onBack }) {
             <span style={{ fontSize: 11, color: t.textMuted, width: 30, flexShrink: 0, fontFamily: "'JetBrains Mono', monospace" }}>
               {String(i + 1).padStart(2, '0')}
             </span>
-            <span style={{ flex: 1, fontSize: 14, color: t.text }}>{row.name}</span>
+            <span style={{ flex: 1, fontSize: 14, color: t.text }}>
+              {row.name}
+              {row.status === 'failed' && row.reason && (
+                <span style={{ display: 'block', fontSize: 11, color: t.textMuted, marginTop: 2 }}>
+                  {formatFailureReason(row.reason)}
+                </span>
+              )}
+            </span>
             <StatusPill status={row.status} />
           </div>
         ))}
@@ -362,6 +383,7 @@ function useAuditController({ onCompleteHistory }) {
   const [phase, setPhase] = useState('idle');
   const [title, setTitle] = useState('');
   const [rows, setRows] = useState([]);
+  const [subtitle, setSubtitle] = useState('');
   const [totals, setTotals] = useState({ banned: 0, legal: 0, failed: 0 });
   const [processed, setProcessed] = useState(0);
   const [total, setTotal] = useState(0);
@@ -377,8 +399,8 @@ function useAuditController({ onCompleteHistory }) {
     }));
   };
 
-  const pushRow = (name, status) => {
-    setRows((prev) => [...prev, { name, status }]);
+  const pushRow = (name, status, reason) => {
+    setRows((prev) => [...prev, { name, status, reason }]);
     setProcessed((value) => value + (status === 'checking' ? 0 : 1));
     if (status !== 'checking') {
       bumpTotals(status);
@@ -389,6 +411,7 @@ function useAuditController({ onCompleteHistory }) {
     setPhase('idle');
     setTitle('');
     setRows([]);
+    setSubtitle('');
     setTotals({ banned: 0, legal: 0, failed: 0 });
     setProcessed(0);
     setTotal(0);
@@ -414,6 +437,7 @@ function useAuditController({ onCompleteHistory }) {
     setPhase('running');
     setTitle(runTitle);
     setRows([]);
+    setSubtitle('');
     setTotals({ banned: 0, legal: 0, failed: 0 });
     setProcessed(0);
     setTotal(0);
@@ -428,13 +452,13 @@ function useAuditController({ onCompleteHistory }) {
     if (mode === 'card') {
       setTotal(1);
       await auditCard(value, {
-        onResult: ({ cardName, status }) => {
+        onResult: ({ cardName, status, reason }) => {
           if (status === 'checking') {
-            setRows([{ name: cardName, status }]);
+            setRows([{ name: cardName, status, reason }]);
             return;
           }
 
-          setRows([{ name: cardName, status }]);
+          setRows([{ name: cardName, status, reason }]);
           setProcessed(1);
           runTotals = {
             banned: status === 'banned' ? 1 : 0,
@@ -463,11 +487,12 @@ function useAuditController({ onCompleteHistory }) {
           runTitle = info.name;
           runTotalCards = info.totalCards;
           setTitle(info.name);
+          setSubtitle(`Deck ID ${info.id}`);
           setTotal(info.totalCards);
         },
-        onCardResult: ({ cardName, status }) => {
+        onCardResult: ({ cardName, status, reason }) => {
           if (abortRef.current.signal.aborted) return;
-          pushRow(cardName, status);
+          pushRow(cardName, status, reason);
         },
         onComplete: (totalsFromAudit) => {
           runTotals = totalsFromAudit;
@@ -496,14 +521,19 @@ function useAuditController({ onCompleteHistory }) {
       onFolderInfo: (info) => {
         runTitle = info.name;
         setTitle(info.name);
+        if (mode === 'folder') {
+          setSubtitle(`Folder ID ${info.id}`);
+        } else {
+          setSubtitle(`User ${info.name}`);
+        }
       },
       onDeckStart: ({ name }) => {
         if (abortRef.current.signal.aborted) return;
         setRows((prev) => [...prev, { name: `Deck: ${name}`, status: 'checking' }]);
       },
-      onDeckCardResult: ({ deckName, cardName, status }) => {
+      onDeckCardResult: ({ deckName, cardName, status, reason }) => {
         if (abortRef.current.signal.aborted) return;
-        pushRow(`${deckName} · ${cardName}`, status);
+        pushRow(`${deckName} · ${cardName}`, status, reason);
       },
       onDeckComplete: ({ deckName, banned, legal, failed }) => {
         runDeckCount += 1;
@@ -533,7 +563,7 @@ function useAuditController({ onCompleteHistory }) {
     });
   };
 
-  return { phase, title, rows, totals, processed, total, error, run, cancel, reset };
+  return { phase, title, subtitle, rows, totals, processed, total, error, run, cancel, reset };
 }
 
 export default function App() {

--- a/src/lib/archidekt.js
+++ b/src/lib/archidekt.js
@@ -1,32 +1,14 @@
 import { ArchidektError } from './errors';
 
-const BASE_URLS = [
-  'https://api.archidekt.com',
-  'https://archidekt.com/api',
-];
+const SERVER_PROXY_BASE = '/api/archidekt';
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function fetchFromAnyBase(path) {
-  let lastError = null;
-
-  for (const baseUrl of BASE_URLS) {
-    try {
-      const response = await fetch(`${baseUrl}${path}`);
-      return response;
-    } catch (error) {
-      lastError = error;
-    }
-  }
-
-  throw lastError || new Error('No Archidekt base URL reachable');
-}
-
 async function archidektFetch(path, retries = 2, attempt = 0) {
   try {
-    const response = await fetchFromAnyBase(path);
+    const response = await fetch(`${SERVER_PROXY_BASE}${path}`);
 
     if (response.status === 404 || response.status === 403) {
       throw new ArchidektError('not_found');
@@ -44,8 +26,8 @@ async function archidektFetch(path, retries = 2, attempt = 0) {
 
     const looksLikeCors = error instanceof TypeError;
     const detail = looksLikeCors
-      ? 'request blocked before response (likely CORS for this origin); try running through a same-origin proxy or deployed domain'
-      : 'unable to reach Archidekt API';
+      ? 'request blocked before response (likely local proxy/network issue)'
+      : 'unable to reach Archidekt API through server proxy';
 
     if (attempt >= retries) {
       throw new ArchidektError('network', detail);

--- a/src/lib/audit.js
+++ b/src/lib/audit.js
@@ -28,7 +28,8 @@ async function auditDeckCards(cardNames, { onCardResult, signal }) {
       }
 
       const status = result?.result ?? 'failed';
-      onCardResult?.({ cardName, status });
+      const reason = result?.reason;
+      onCardResult?.({ cardName, status, reason });
 
       if (status === 'banned') {
         totals.banned += 1;

--- a/src/lib/scryfall.js
+++ b/src/lib/scryfall.js
@@ -4,6 +4,7 @@ import { db } from './db';
 const DAY_MS = 24 * 60 * 60 * 1000;
 const CACHE_TTL_MS = 30 * DAY_MS;
 const UA = 'MiddleClassCommander/1.0 (https://github.com/example/mcc)';
+const SCRYFALL_PROXY_BASE = '/api/scryfall';
 
 const bannedSetCodes = new Set(
   setData.sets
@@ -11,17 +12,34 @@ const bannedSetCodes = new Set(
     .map((entry) => entry.code.toLowerCase()),
 );
 
+const inFlightByCardName = new Map();
+
 const queueState = {
   queue: [],
   active: 0,
-  maxConcurrent: 5,
-  minDelayMs: 100,
+  maxConcurrent: 2,
+  minDelayMs: 130,
   lastStartAt: 0,
   pumping: false,
 };
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildScryfallUrl(path) {
+  return `${SCRYFALL_PROXY_BASE}${path}`;
+}
+
+function getRetryDelayMs(response, attempt, baseDelayMs) {
+  const retryAfterHeader = response?.headers?.get?.('Retry-After');
+  const retryAfterSeconds = Number(retryAfterHeader);
+
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return retryAfterSeconds * 1000;
+  }
+
+  return 2 ** attempt * baseDelayMs;
 }
 
 function pumpQueue() {
@@ -75,10 +93,10 @@ function enqueueRequest(executor) {
   });
 }
 
-async function scryfallFetch(url, retries = 3, attempt = 0) {
+async function scryfallFetch(path, retries = 4, attempt = 0) {
   try {
     const response = await enqueueRequest(() =>
-      fetch(url, {
+      fetch(buildScryfallUrl(path), {
         headers: {
           'User-Agent': UA,
         },
@@ -94,8 +112,8 @@ async function scryfallFetch(url, retries = 3, attempt = 0) {
         return { failed: 'rate_limited' };
       }
 
-      await sleep(2 ** attempt * 350);
-      return scryfallFetch(url, retries, attempt + 1);
+      await sleep(getRetryDelayMs(response, attempt, 400));
+      return scryfallFetch(path, retries, attempt + 1);
     }
 
     if (!response.ok) {
@@ -108,8 +126,8 @@ async function scryfallFetch(url, retries = 3, attempt = 0) {
       return { failed: 'network' };
     }
 
-    await sleep(2 ** attempt * 250);
-    return scryfallFetch(url, retries, attempt + 1);
+    await sleep(2 ** attempt * 300);
+    return scryfallFetch(path, retries, attempt + 1);
   }
 }
 
@@ -135,7 +153,7 @@ export async function checkForSetListUpdatesIfStale() {
     return;
   }
 
-  const setListResponse = await scryfallFetch('https://api.scryfall.com/sets');
+  const setListResponse = await scryfallFetch('/sets');
   if (!setListResponse || setListResponse.failed || !Array.isArray(setListResponse.data)) {
     return;
   }
@@ -149,19 +167,9 @@ export async function checkForSetListUpdatesIfStale() {
   await db.setListMeta.put({ key: 'lastSetCheck', checkedAt: new Date().toISOString() });
 }
 
-export async function checkCard(cardName) {
-  const normalized = normalizeCardName(cardName);
-  if (!normalized) {
-    return { result: 'failed', reason: 'not_found' };
-  }
-
-  const cached = await db.cardCache.get(normalized);
-  if (cacheStillValid(cached)) {
-    return { result: cached.result, printings: cached.printings };
-  }
-
-  const url = `https://api.scryfall.com/cards/search?q=${encodeURIComponent(`!"${normalized}"`)}&unique=prints&order=released`;
-  const payload = await scryfallFetch(url);
+async function checkCardUncached(normalized) {
+  const path = `/cards/search?q=${encodeURIComponent(`!\"${normalized}\"`)}&unique=prints&order=released`;
+  const payload = await scryfallFetch(path);
 
   if (payload?.failed) {
     return { result: 'failed', reason: payload.failed };
@@ -199,4 +207,28 @@ export async function checkCard(cardName) {
   });
 
   return { result, printings };
+}
+
+export async function checkCard(cardName) {
+  const normalized = normalizeCardName(cardName);
+  if (!normalized) {
+    return { result: 'failed', reason: 'not_found' };
+  }
+
+  const cached = await db.cardCache.get(normalized);
+  if (cacheStillValid(cached)) {
+    return { result: cached.result, printings: cached.printings };
+  }
+
+  const inFlight = inFlightByCardName.get(normalized);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const lookupPromise = checkCardUncached(normalized).finally(() => {
+    inFlightByCardName.delete(normalized);
+  });
+
+  inFlightByCardName.set(normalized, lookupPromise);
+  return lookupPromise;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,25 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const ARCHIDEKT_TARGET = 'https://archidekt.com';
+const ARCHIDEKT_PROXY_PREFIX = '/api/archidekt';
+
+const archidektProxy = {
+  target: ARCHIDEKT_TARGET,
+  changeOrigin: true,
+  rewrite: (path) => path.replace(/^\/api\/archidekt/, '/api'),
+};
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      [ARCHIDEKT_PROXY_PREFIX]: archidektProxy,
+    },
+  },
+  preview: {
+    proxy: {
+      [ARCHIDEKT_PROXY_PREFIX]: archidektProxy,
+    },
+  },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 
 const ARCHIDEKT_TARGET = 'https://archidekt.com';
 const ARCHIDEKT_PROXY_PREFIX = '/api/archidekt';
+const SCRYFALL_TARGET = 'https://api.scryfall.com';
+const SCRYFALL_PROXY_PREFIX = '/api/scryfall';
 
 const archidektProxy = {
   target: ARCHIDEKT_TARGET,
@@ -10,16 +12,23 @@ const archidektProxy = {
   rewrite: (path) => path.replace(/^\/api\/archidekt/, '/api'),
 };
 
+const scryfallProxy = {
+  target: SCRYFALL_TARGET,
+  changeOrigin: true,
+  rewrite: (path) => path.replace(/^\/api\/scryfall/, ''),
+};
+
+const proxyConfig = {
+  [ARCHIDEKT_PROXY_PREFIX]: archidektProxy,
+  [SCRYFALL_PROXY_PREFIX]: scryfallProxy,
+};
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    proxy: {
-      [ARCHIDEKT_PROXY_PREFIX]: archidektProxy,
-    },
+    proxy: proxyConfig,
   },
   preview: {
-    proxy: {
-      [ARCHIDEKT_PROXY_PREFIX]: archidektProxy,
-    },
+    proxy: proxyConfig,
   },
 });


### PR DESCRIPTION
### Motivation

- Browser-origin requests to Archidekt are subject to CORS and can be blocked, so requests should be proxied server-side to avoid those issues.
- Provide a same-origin endpoint during development/preview so the frontend can fetch Archidekt data without relying on client-side CORS workarounds.

### Description

- Switch the Archidekt client to hit a same-origin proxy by adding `SERVER_PROXY_BASE = '/api/archidekt'` and using `fetch(`${SERVER_PROXY_BASE}${path}`)` in `src/lib/archidekt.js` instead of calling Archidekt directly.
- Remove the previous multi-base fetch logic and update network error messages to reference the server proxy path.
- Add a Vite proxy configuration in `vite.config.js` that forwards `/api/archidekt/*` to `https://archidekt.com/api/*` for both `server` and `preview` modes.
- Update `README.md` to document that Archidekt requests are routed through the Vite server-side proxy.

### Testing

- `node --check src/lib/archidekt.js` and `node --check vite.config.js` were run and succeeded.
- `npm run build` was attempted but failed in this environment because `vite` is not available from installed dependencies, so a production build could not be validated here.
- An attempt to verify Archidekt documentation online was blocked by the runtime network (CONNECT tunnel 403), so external API docs could not be fetched from this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb6b26e988320b0ce8a79919e6fe6)