### PR TITLE
Add Clear Cache button with confirmation modal in header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,23 +20,11 @@ const t = {
   warningSoft: '#1c1400',
 };
 
-const DEFAULT_HISTORY = {
-  card: [
-    { id: 'Sol Ring', name: 'Sol Ring', banned: true, ts: 'Today, 9:41 AM' },
-    { id: 'Command Tower', name: 'Command Tower', banned: false, ts: 'Today, 9:39 AM' },
-  ],
-  deck: [
-    { id: '182733', name: 'Atraxa Superfriends', banned: 12, total: 100, ts: 'Today, 9:41 AM' },
-    { id: '204910', name: 'Krenko Goblin Tribal', banned: 2, total: 87, ts: 'Yesterday' },
-  ],
-  folder: [
-    { id: 'f-8821', name: 'Competitive Builds', deckCount: 6, banned: 18, ts: 'Today, 8:02 AM' },
-    { id: 'f-7743', name: 'Casual Night', deckCount: 4, banned: 3, ts: 'Feb 22' },
-  ],
-  user: [
-    { id: 'grindstone99', name: 'grindstone99', deckCount: 14, banned: 31, ts: 'Today, 7:55 AM' },
-    { id: 'spellslinger', name: 'spellslinger', deckCount: 7, banned: 5, ts: 'Feb 20' },
-  ],
+const EMPTY_HISTORY = {
+  card: [],
+  deck: [],
+  folder: [],
+  user: [],
 };
 
 const HISTORY_STORAGE_KEY = 'mcc-history-v1';
@@ -54,22 +42,22 @@ function loadHistory() {
   try {
     const raw = localStorage.getItem(HISTORY_STORAGE_KEY);
     if (!raw) {
-      return DEFAULT_HISTORY;
+      return EMPTY_HISTORY;
     }
 
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') {
-      return DEFAULT_HISTORY;
+      return EMPTY_HISTORY;
     }
 
     return {
-      card: Array.isArray(parsed.card) ? parsed.card : DEFAULT_HISTORY.card,
-      deck: Array.isArray(parsed.deck) ? parsed.deck : DEFAULT_HISTORY.deck,
-      folder: Array.isArray(parsed.folder) ? parsed.folder : DEFAULT_HISTORY.folder,
-      user: Array.isArray(parsed.user) ? parsed.user : DEFAULT_HISTORY.user,
+      card: Array.isArray(parsed.card) ? parsed.card : EMPTY_HISTORY.card,
+      deck: Array.isArray(parsed.deck) ? parsed.deck : EMPTY_HISTORY.deck,
+      folder: Array.isArray(parsed.folder) ? parsed.folder : EMPTY_HISTORY.folder,
+      user: Array.isArray(parsed.user) ? parsed.user : EMPTY_HISTORY.user,
     };
   } catch {
-    return DEFAULT_HISTORY;
+    return EMPTY_HISTORY;
   }
 }
 
@@ -572,7 +560,9 @@ export default function App() {
   const [history, setHistory] = useState(loadHistory);
   const [entryMode, setEntryMode] = useState('card');
   const [showClearCacheModal, setShowClearCacheModal] = useState(false);
+  const [showClearHistoryModal, setShowClearHistoryModal] = useState(false);
   const [isClearingCache, setIsClearingCache] = useState(false);
+  const [isClearingHistory, setIsClearingHistory] = useState(false);
 
   useEffect(() => {
     localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
@@ -600,6 +590,14 @@ export default function App() {
     setShowClearCacheModal(false);
   };
 
+  const handleConfirmClearHistory = () => {
+    setIsClearingHistory(true);
+    setHistory(EMPTY_HISTORY);
+    localStorage.removeItem(HISTORY_STORAGE_KEY);
+    setIsClearingHistory(false);
+    setShowClearHistoryModal(false);
+  };
+
   return (
     <div style={{ minHeight: '100vh', background: t.bg, color: t.text, fontFamily: "'Inter', 'Helvetica Neue', sans-serif" }}>
       <style>{`
@@ -612,7 +610,23 @@ export default function App() {
 
       <div style={{ borderBottom: `1px solid ${t.border}`, padding: '13px 32px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: t.surface }}>
         <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '-0.01em', color: t.text }}>Middle Class Commander</span>
-        <button
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <button
+            onClick={() => setShowClearHistoryModal(true)}
+            style={{
+              border: `1px solid ${t.border}`,
+              borderRadius: 6,
+              background: 'transparent',
+              color: t.textDim,
+              fontSize: 12,
+              fontWeight: 600,
+              padding: '6px 12px',
+              cursor: 'pointer',
+            }}
+          >
+            Clear History
+          </button>
+          <button
           onClick={() => setShowClearCacheModal(true)}
           style={{
             border: `1px solid ${t.border}`,
@@ -627,6 +641,7 @@ export default function App() {
         >
           Clear Cache
         </button>
+        </div>
       </div>
 
       <div style={{ padding: '0 32px' }}>
@@ -683,6 +698,62 @@ export default function App() {
                 }}
               >
                 {isClearingCache ? 'Clearing…' : 'Delete Cache'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+
+      {showClearHistoryModal && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: '#000000a8',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24,
+          }}
+        >
+          <div style={{ width: '100%', maxWidth: 420, background: t.surface, border: `1px solid ${t.border}`, borderRadius: 12, padding: 20 }}>
+            <div style={{ fontSize: 18, fontWeight: 600, color: t.text, marginBottom: 8 }}>Delete search history?</div>
+            <p style={{ fontSize: 13, color: t.textMuted, marginBottom: 16 }}>
+              This will clear all recent card, deck, folder, and user lookups from this device.
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button
+                onClick={() => setShowClearHistoryModal(false)}
+                disabled={isClearingHistory}
+                style={{
+                  border: `1px solid ${t.border}`,
+                  borderRadius: 6,
+                  background: 'transparent',
+                  color: t.textDim,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  padding: '8px 12px',
+                  cursor: isClearingHistory ? 'default' : 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmClearHistory}
+                disabled={isClearingHistory}
+                style={{
+                  border: 'none',
+                  borderRadius: 6,
+                  background: t.banned,
+                  color: '#fff',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  padding: '8px 12px',
+                  cursor: isClearingHistory ? 'default' : 'pointer',
+                }}
+              >
+                {isClearingHistory ? 'Clearing…' : 'Delete History'}
               </button>
             </div>
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { auditCard, auditDeck, auditFolder, auditUser } from './lib/audit';
+import { clearCache } from './lib/cache';
 
 const t = {
   bg: '#0f1117',
@@ -570,6 +571,8 @@ export default function App() {
   const [view, setView] = useState('entry');
   const [history, setHistory] = useState(loadHistory);
   const [entryMode, setEntryMode] = useState('card');
+  const [showClearCacheModal, setShowClearCacheModal] = useState(false);
+  const [isClearingCache, setIsClearingCache] = useState(false);
 
   useEffect(() => {
     localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
@@ -590,6 +593,13 @@ export default function App() {
     await audit.run(mode, value, nameHint);
   };
 
+  const handleConfirmClearCache = async () => {
+    setIsClearingCache(true);
+    await clearCache();
+    setIsClearingCache(false);
+    setShowClearCacheModal(false);
+  };
+
   return (
     <div style={{ minHeight: '100vh', background: t.bg, color: t.text, fontFamily: "'Inter', 'Helvetica Neue', sans-serif" }}>
       <style>{`
@@ -600,14 +610,84 @@ export default function App() {
         button:hover { opacity: 0.82; }
       `}</style>
 
-      <div style={{ borderBottom: `1px solid ${t.border}`, padding: '13px 32px', display: 'flex', alignItems: 'center', background: t.surface }}>
+      <div style={{ borderBottom: `1px solid ${t.border}`, padding: '13px 32px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: t.surface }}>
         <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: '-0.01em', color: t.text }}>Middle Class Commander</span>
+        <button
+          onClick={() => setShowClearCacheModal(true)}
+          style={{
+            border: `1px solid ${t.border}`,
+            borderRadius: 6,
+            background: 'transparent',
+            color: t.textDim,
+            fontSize: 12,
+            fontWeight: 600,
+            padding: '6px 12px',
+            cursor: 'pointer',
+          }}
+        >
+          Clear Cache
+        </button>
       </div>
 
       <div style={{ padding: '0 32px' }}>
         {view === 'entry' && <EntryPage onSubmit={handleSubmit} history={history} mode={entryMode} onModeChange={setEntryMode} />}
         {view === 'results' && <ResultsView audit={audit} onBack={() => setView('entry')} />}
       </div>
+
+      {showClearCacheModal && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: '#000000a8',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24,
+          }}
+        >
+          <div style={{ width: '100%', maxWidth: 420, background: t.surface, border: `1px solid ${t.border}`, borderRadius: 12, padding: 20 }}>
+            <div style={{ fontSize: 18, fontWeight: 600, color: t.text, marginBottom: 8 }}>Delete cached card data?</div>
+            <p style={{ fontSize: 13, color: t.textMuted, marginBottom: 16 }}>
+              This will remove cached results for all cards. Future checks may take longer until cache is rebuilt.
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button
+                onClick={() => setShowClearCacheModal(false)}
+                disabled={isClearingCache}
+                style={{
+                  border: `1px solid ${t.border}`,
+                  borderRadius: 6,
+                  background: 'transparent',
+                  color: t.textDim,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  padding: '8px 12px',
+                  cursor: isClearingCache ? 'default' : 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmClearCache}
+                disabled={isClearingCache}
+                style={{
+                  border: 'none',
+                  borderRadius: 6,
+                  background: t.banned,
+                  color: '#fff',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  padding: '8px 12px',
+                  cursor: isClearingCache ? 'default' : 'pointer',
+                }}
+              >
+                {isClearingCache ? 'Clearing…' : 'Delete Cache'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a user-accessible control to remove all cached card data from the UI so users can force cache refreshes when desired.

### Description
- Imported the existing cache helper by adding `import { clearCache } from './lib/cache'` to `src/App.jsx` and added two pieces of component state: `showClearCacheModal` and `isClearingCache`.
- Added a new `Clear Cache` button in the top header and adjusted header layout with `justifyContent: 'space-between'` to position it on the right.
- Implemented a confirmation modal that opens on button click and exposes `Cancel` and `Delete Cache` actions, where `Delete Cache` calls the `handleConfirmClearCache` handler which invokes `clearCache()` and disables modal actions while the deletion is in progress.
- All UI changes were applied in `src/App.jsx` and the modal closes after the cache clear completes.

### Testing
- Ran a production build with `npm run build` which completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` to verify the UI and confirm the header button and modal appear as expected.
- Captured a browser screenshot via an automated Playwright script to validate the header button and modal rendering; the script executed and produced the artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0bbe99d7483209076dbc1c0a96b4c)