### PR TITLE
Make Scryfall client testable, add runtime abstraction and policy tests, and set proxy headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ npm run dev
 http://localhost:5173
 ```
 
+## Run tests
+
+```bash
+npm test
+```
+
 ## Build for production
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "dexie": "^4.0.8",

--- a/src/lib/scryfall.js
+++ b/src/lib/scryfall.js
@@ -1,9 +1,7 @@
-import setData from '../data/sets.json';
-import { db } from './db';
+import setData from '../data/sets.json' with { type: 'json' };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const CACHE_TTL_MS = 30 * DAY_MS;
-const UA = 'MiddleClassCommander/1.0 (https://github.com/example/mcc)';
 const SCRYFALL_PROXY_BASE = '/api/scryfall';
 
 const bannedSetCodes = new Set(
@@ -23,9 +21,40 @@ const queueState = {
   pumping: false,
 };
 
+function createInMemoryDb() {
+  const cardCacheStore = new Map();
+  const setListMetaStore = new Map();
+
+  return {
+    cardCache: {
+      async get(key) {
+        return cardCacheStore.get(key);
+      },
+      async put(value) {
+        cardCacheStore.set(value.cardName, value);
+      },
+    },
+    setListMeta: {
+      async get(key) {
+        return setListMetaStore.get(key);
+      },
+      async put(value) {
+        setListMetaStore.set(value.key, value);
+      },
+    },
+  };
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+const runtime = {
+  fetchImpl: (...args) => fetch(...args),
+  sleepImpl: sleep,
+  now: () => Date.now(),
+  dbImpl: createInMemoryDb(),
+};
 
 function buildScryfallUrl(path) {
   return `${SCRYFALL_PROXY_BASE}${path}`;
@@ -51,10 +80,10 @@ function pumpQueue() {
 
   const tick = async () => {
     while (queueState.active < queueState.maxConcurrent && queueState.queue.length > 0) {
-      const now = Date.now();
+      const now = runtime.now();
       const wait = Math.max(0, queueState.lastStartAt + queueState.minDelayMs - now);
       if (wait > 0) {
-        await sleep(wait);
+        await runtime.sleepImpl(wait);
       }
 
       const next = queueState.queue.shift();
@@ -62,7 +91,7 @@ function pumpQueue() {
         break;
       }
 
-      queueState.lastStartAt = Date.now();
+      queueState.lastStartAt = runtime.now();
       queueState.active += 1;
 
       next()
@@ -96,9 +125,9 @@ function enqueueRequest(executor) {
 async function scryfallFetch(path, retries = 4, attempt = 0) {
   try {
     const response = await enqueueRequest(() =>
-      fetch(buildScryfallUrl(path), {
+      runtime.fetchImpl(buildScryfallUrl(path), {
         headers: {
-          'User-Agent': UA,
+          Accept: 'application/json;q=0.9,*/*;q=0.8',
         },
       }),
     );
@@ -112,7 +141,7 @@ async function scryfallFetch(path, retries = 4, attempt = 0) {
         return { failed: 'rate_limited' };
       }
 
-      await sleep(getRetryDelayMs(response, attempt, 400));
+      await runtime.sleepImpl(getRetryDelayMs(response, attempt, 400));
       return scryfallFetch(path, retries, attempt + 1);
     }
 
@@ -126,7 +155,7 @@ async function scryfallFetch(path, retries = 4, attempt = 0) {
       return { failed: 'network' };
     }
 
-    await sleep(2 ** attempt * 300);
+    await runtime.sleepImpl(2 ** attempt * 300);
     return scryfallFetch(path, retries, attempt + 1);
   }
 }
@@ -141,15 +170,19 @@ function cacheStillValid(entry) {
   }
 
   const cachedAt = new Date(entry.cachedAt).getTime();
-  const notExpired = Date.now() - cachedAt < CACHE_TTL_MS;
+  const notExpired = runtime.now() - cachedAt < CACHE_TTL_MS;
   const versionMatches = entry.setListVersion === setData.version;
 
   return notExpired && versionMatches;
 }
 
+export function setScryfallDb(dbImpl) {
+  runtime.dbImpl = dbImpl;
+}
+
 export async function checkForSetListUpdatesIfStale() {
-  const meta = await db.setListMeta.get('lastSetCheck');
-  if (meta?.checkedAt && Date.now() - new Date(meta.checkedAt).getTime() < DAY_MS) {
+  const meta = await runtime.dbImpl.setListMeta.get('lastSetCheck');
+  if (meta?.checkedAt && runtime.now() - new Date(meta.checkedAt).getTime() < DAY_MS) {
     return;
   }
 
@@ -164,7 +197,7 @@ export async function checkForSetListUpdatesIfStale() {
     console.warn('New Scryfall sets not in sets.json:', unknownSets.map((entry) => entry.code));
   }
 
-  await db.setListMeta.put({ key: 'lastSetCheck', checkedAt: new Date().toISOString() });
+  await runtime.dbImpl.setListMeta.put({ key: 'lastSetCheck', checkedAt: new Date(runtime.now()).toISOString() });
 }
 
 async function checkCardUncached(normalized) {
@@ -198,11 +231,11 @@ async function checkCardUncached(normalized) {
 
   const result = isBanned ? 'banned' : 'legal';
 
-  await db.cardCache.put({
+  await runtime.dbImpl.cardCache.put({
     cardName: normalized,
     result,
     printings,
-    cachedAt: new Date().toISOString(),
+    cachedAt: new Date(runtime.now()).toISOString(),
     setListVersion: setData.version,
   });
 
@@ -215,7 +248,7 @@ export async function checkCard(cardName) {
     return { result: 'failed', reason: 'not_found' };
   }
 
-  const cached = await db.cardCache.get(normalized);
+  const cached = await runtime.dbImpl.cardCache.get(normalized);
   if (cacheStillValid(cached)) {
     return { result: cached.result, printings: cached.printings };
   }
@@ -232,3 +265,21 @@ export async function checkCard(cardName) {
   inFlightByCardName.set(normalized, lookupPromise);
   return lookupPromise;
 }
+
+export function __setScryfallTestRuntime(overrides = {}) {
+  Object.assign(runtime, overrides);
+}
+
+export function __resetScryfallTestState() {
+  inFlightByCardName.clear();
+  queueState.queue = [];
+  queueState.active = 0;
+  queueState.lastStartAt = 0;
+  queueState.pumping = false;
+}
+
+export const __scryfallTestConstants = {
+  DAY_MS,
+  CACHE_TTL_MS,
+  queueState,
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { checkForSetListUpdatesIfStale } from './lib/scryfall';
+import { db } from './lib/db';
+import { checkForSetListUpdatesIfStale, setScryfallDb } from './lib/scryfall';
 
+setScryfallDb(db);
 checkForSetListUpdatesIfStale().catch(() => null);
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/test/scryfall.policy.test.js
+++ b/test/scryfall.policy.test.js
@@ -1,0 +1,223 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import setData from '../src/data/sets.json' with { type: 'json' };
+import {
+  __resetScryfallTestState,
+  __setScryfallTestRuntime,
+  __scryfallTestConstants,
+  checkCard,
+} from '../src/lib/scryfall.js';
+
+function createDb() {
+  const cardCache = new Map();
+  const setListMeta = new Map();
+
+  return {
+    cardCache,
+    setListMeta,
+    impl: {
+      cardCache: {
+        async get(key) {
+          return cardCache.get(key);
+        },
+        async put(value) {
+          cardCache.set(value.cardName, value);
+        },
+      },
+      setListMeta: {
+        async get(key) {
+          return setListMeta.get(key);
+        },
+        async put(value) {
+          setListMeta.set(value.key, value);
+        },
+      },
+    },
+  };
+}
+
+function createResponse(status, body, headers = {}) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get(name) {
+        return headers[name] ?? null;
+      },
+    },
+    async json() {
+      return body;
+    },
+  };
+}
+
+function validCardPayload(name = 'Sol Ring') {
+  return {
+    data: [
+      {
+        name,
+        set: 'lea',
+        rarity: 'common',
+        released_at: '1993-08-05',
+      },
+    ],
+  };
+}
+
+test.beforeEach(() => {
+  __resetScryfallTestState();
+});
+
+test('browser request includes Accept header and does not override User-Agent', async () => {
+  const db = createDb();
+  let fetchOptions;
+
+  __setScryfallTestRuntime({
+    dbImpl: db.impl,
+    now: () => Date.now(),
+    sleepImpl: async () => {},
+    fetchImpl: async (_url, options) => {
+      fetchOptions = options;
+      return createResponse(200, validCardPayload());
+    },
+  });
+
+  await checkCard('Sol Ring');
+
+  assert.equal(fetchOptions.headers.Accept, 'application/json;q=0.9,*/*;q=0.8');
+  assert.equal('User-Agent' in fetchOptions.headers, false);
+});
+
+test('vite proxy config sets accurate User-Agent and Accept headers for Scryfall', () => {
+  const viteConfigText = fs.readFileSync(new URL('../vite.config.js', import.meta.url), 'utf8');
+
+  assert.match(viteConfigText, /APP_USER_AGENT = `\$\{APP_NAME\}\/\$\{APP_VERSION\}`/);
+  assert.match(viteConfigText, /'User-Agent': APP_USER_AGENT/);
+  assert.match(viteConfigText, /Accept: DEFAULT_ACCEPT/);
+});
+
+test('queue enforces at least 100ms spacing and max concurrency', async () => {
+  const db = createDb();
+  let fakeNow = 0;
+  let inFlight = 0;
+  let peakInFlight = 0;
+  const startTimes = [];
+
+  __setScryfallTestRuntime({
+    dbImpl: db.impl,
+    now: () => fakeNow,
+    sleepImpl: async (ms) => {
+      fakeNow += ms;
+    },
+    fetchImpl: async () => {
+      startTimes.push(fakeNow);
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      fakeNow += 10;
+      inFlight -= 1;
+      return createResponse(200, validCardPayload());
+    },
+  });
+
+  await Promise.all([
+    checkCard('Alpha'),
+    checkCard('Beta'),
+    checkCard('Gamma'),
+    checkCard('Delta'),
+    checkCard('Epsilon'),
+  ]);
+
+  assert.ok(peakInFlight <= __scryfallTestConstants.queueState.maxConcurrent);
+  for (let i = 1; i < startTimes.length; i += 1) {
+    assert.ok(startTimes[i] - startTimes[i - 1] >= 100);
+  }
+});
+
+test('429 retry respects Retry-After', async () => {
+  const db = createDb();
+  let fakeNow = 0;
+  const startTimes = [];
+  let callCount = 0;
+
+  __setScryfallTestRuntime({
+    dbImpl: db.impl,
+    now: () => fakeNow,
+    sleepImpl: async (ms) => {
+      fakeNow += ms;
+    },
+    fetchImpl: async () => {
+      startTimes.push(fakeNow);
+      callCount += 1;
+      if (callCount === 1) {
+        return createResponse(429, {}, { 'Retry-After': '2' });
+      }
+
+      return createResponse(200, validCardPayload('Retry Card'));
+    },
+  });
+
+  const result = await checkCard('Retry Card');
+
+  assert.equal(result.result, 'legal');
+  assert.equal(startTimes.length, 2);
+  assert.ok(startTimes[1] - startTimes[0] >= 2000);
+});
+
+test('cache entries under 24 hours skip network fetches', async () => {
+  const db = createDb();
+  const now = Date.now();
+  let fetchCalls = 0;
+
+  db.cardCache.set('cached card', {
+    cardName: 'cached card',
+    result: 'legal',
+    printings: [],
+    cachedAt: new Date(now - __scryfallTestConstants.DAY_MS + 1).toISOString(),
+    setListVersion: setData.version,
+  });
+
+  __setScryfallTestRuntime({
+    dbImpl: db.impl,
+    now: () => now,
+    sleepImpl: async () => {},
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return createResponse(200, validCardPayload());
+    },
+  });
+
+  const result = await checkCard('cached card');
+
+  assert.equal(result.result, 'legal');
+  assert.equal(fetchCalls, 0);
+  assert.ok(__scryfallTestConstants.CACHE_TTL_MS >= __scryfallTestConstants.DAY_MS);
+});
+
+test('in-flight requests are deduplicated for the same card name', async () => {
+  const db = createDb();
+  let fetchCalls = 0;
+  let pendingResolve;
+  const pending = new Promise((resolve) => {
+    pendingResolve = resolve;
+  });
+
+  __setScryfallTestRuntime({
+    dbImpl: db.impl,
+    now: () => Date.now(),
+    sleepImpl: async () => {},
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      await pending;
+      return createResponse(200, validCardPayload('Shared Name'));
+    },
+  });
+
+  const first = checkCard('Shared Name');
+  const second = checkCard('Shared Name');
+
+  pendingResolve();
+  await Promise.all([first, second]);
+
+  assert.equal(fetchCalls, 1);
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,10 @@ const ARCHIDEKT_TARGET = 'https://archidekt.com';
 const ARCHIDEKT_PROXY_PREFIX = '/api/archidekt';
 const SCRYFALL_TARGET = 'https://api.scryfall.com';
 const SCRYFALL_PROXY_PREFIX = '/api/scryfall';
+const APP_NAME = process.env.npm_package_name ?? 'middle-class-commander';
+const APP_VERSION = process.env.npm_package_version ?? '1.0.0';
+const APP_USER_AGENT = `${APP_NAME}/${APP_VERSION}`;
+const DEFAULT_ACCEPT = 'application/json;q=0.9,*/*;q=0.8';
 
 const archidektProxy = {
   target: ARCHIDEKT_TARGET,
@@ -15,6 +19,10 @@ const archidektProxy = {
 const scryfallProxy = {
   target: SCRYFALL_TARGET,
   changeOrigin: true,
+  headers: {
+    'User-Agent': APP_USER_AGENT,
+    Accept: DEFAULT_ACCEPT,
+  },
   rewrite: (path) => path.replace(/^\/api\/scryfall/, ''),
 };
 


### PR DESCRIPTION
### Motivation

- Make the Scryfall client deterministic and unit-testable by removing hard dependencies on global `fetch`, `Date`, sleep logic, and the IndexedDB wrapper. 
- Ensure the dev/prod Vite proxy forwards a stable `User-Agent` and `Accept` header to Scryfall to match test expectations. 
- Add automated tests that validate request headers, queue timing, retry behavior, caching, and in-flight deduplication for the Scryfall logic.

### Description

- Introduce a runtime abstraction object and in-memory fallback DB (`createInMemoryDb`) and replace direct uses of `fetch`, `Date.now()`, `sleep`, and `db` with `runtime` calls. 
- Expose API functions `setScryfallDb`, `__setScryfallTestRuntime`, `__resetScryfallTestState`, and `__scryfallTestConstants` for wiring real DB at app startup and for tests. 
- Wire the app to the real Dexie DB by calling `setScryfallDb(db)` in `src/main.jsx`. 
- Add Vite config constants and proxy headers (`User-Agent` and `Accept`) in `vite.config.js`. 
- Add a Node test runner script `test` in `package.json` and document `Run tests` in `README.md`. 
- Add comprehensive tests in `test/scryfall.policy.test.js` covering header composition, proxy config text, queue spacing and concurrency, 429 retry `Retry-After` handling, cache TTL behavior, and in-flight deduplication.

### Testing

- Ran `npm test` (which invokes `node --test`) to execute `test/scryfall.policy.test.js`.
- All 6 tests in `test/scryfall.policy.test.js` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5cdea6f608320ab5070498dcaab4a)